### PR TITLE
Support for custom script source.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+Unreleased
+=====
+
+* Support for custom analytics script src (so for example DoubleClick is supported).
+
 0.0.3
 =====
 

--- a/README.markdown
+++ b/README.markdown
@@ -31,6 +31,15 @@ Production only
 
 		<%= analytics_init if Rails.env.production? %>
 
+With DoubleClick instead of vanilla Google Analytics script
+-----------------------------------------------------------
+
+`config/environments/production.rb`:
+
+    # replace this with your tracker code
+    GA.tracker = "UA-xxxxxx-x"
+    GA.source_script = "('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js'"
+
 
 Different accounts for development and production
 -------------------------------------------------

--- a/lib/google-analytics-rails.rb
+++ b/lib/google-analytics-rails.rb
@@ -4,6 +4,8 @@ require 'google-analytics/events'
 module GoogleAnalytics
   # @private
   PLACEHOLDER_TRACKER = "UA-xxxxxx-x"
+  # @private
+  DEFAULT_SCRIPT_SOURCE = "('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js'"
 
   # Get the current tracker id (*UA-xxxxxx-x*).
   # @return [String]
@@ -20,6 +22,24 @@ module GoogleAnalytics
   # @return [Boolean]
   def self.valid_tracker?
     tracker.nil? || tracker == "" || tracker == PLACEHOLDER_TRACKER ? false : true
+  end
+
+  # Get the current ga src.
+  # This allows for example to use the compatible doubleclick code :
+  # ```
+  #   ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js'
+  # ```
+  # @see http://support.google.com/analytics/bin/answer.py?hl=en&answer=2444872 for more info
+  #
+  # @return [String]
+  def self.script_source
+    @@src ||= DEFAULT_SCRIPT_SOURCE
+  end
+
+  # Set the current ga src.
+  # @return [String]
+  def self.script_source=(src)
+    @@src = src
   end
 end
 

--- a/lib/google-analytics/async_tracking_queue.rb
+++ b/lib/google-analytics/async_tracking_queue.rb
@@ -19,7 +19,7 @@ var _gaq = _gaq || [];
 #{@events.map { |event| event.to_s }.join("\n")}
 (function() {
 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+ga.src = #{GoogleAnalytics.script_source};
 var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 })();
 </script>

--- a/test/async_tracking_queue_test.rb
+++ b/test/async_tracking_queue_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class AsyncTrackingQueueTest < Test::Unit::TestCase
+  def teardown
+    GoogleAnalytics.script_source = nil
+  end
+
   VALID_SNIPPET = <<-JAVASCRIPT
 <script type="text/javascript">
 var _gaq = _gaq || [];
@@ -28,5 +32,35 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga
     gaq.push(GA::Event.new('event2', 2), 't2')
 
     assert_equal(VALID_SNIPPET, gaq.to_s)
+  end
+
+  VALID_DOUBLECLICK_SNIPPET = <<-JAVASCRIPT
+<script type="text/javascript">
+var _gaq = _gaq || [];
+_gaq.push(['event1',1]);
+_gaq.push(['event2',2]);
+_gaq.push(['t2.event1',1]);
+_gaq.push(['t2.event2',2]);
+(function() {
+var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
+var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+})();
+</script>
+  JAVASCRIPT
+
+  def test_queue_renders_valid_javascript_snippit_with_custom_src
+    GoogleAnalytics.script_source = "('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js'"
+    gaq = GAQ.new
+
+    # Add 2 events to the default tracker
+    gaq << GA::Event.new('event1', 1)
+    gaq << GA::Event.new('event2', 2)
+
+    # Add 2 events for an alternate tracker
+    gaq.push(GA::Event.new('event1', 1), 't2')
+    gaq.push(GA::Event.new('event2', 2), 't2')
+
+    assert_equal(VALID_DOUBLECLICK_SNIPPET, gaq.to_s)
   end
 end


### PR DESCRIPTION
This adds support to use the DoubleClick tracking code which enables
'Display Advertising' as described here:
http://support.google.com/analytics/bin/answer.py?hl=en&answer=2444872
