### PR TITLE
Defaults to the current code for Analytics with doubleclick enabled

### DIFF
--- a/google-analytics-rails.gemspec
+++ b/google-analytics-rails.gemspec
@@ -3,14 +3,15 @@ $:.push File.expand_path("../lib", __FILE__)
 require "google-analytics/version"
 
 Gem::Specification.new do |s|
-  s.name        = "google-analytics-rails"
-  s.version     = GoogleAnalytics::VERSION
-  s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Benoit Garret"]
-  s.email       = ["benoit.garret@gadz.org"]
-  s.homepage    = "https://github.com/bgarret/google-analytics-rails"
-  s.summary     = %q{Rails 3 helpers to manage google analytics tracking}
-  s.description = %q{Rails 3 helpers to manage google analytics tracking}
+  s.name                 = "google-analytics-rails"
+  s.version              = GoogleAnalytics::VERSION
+  s.platform             = Gem::Platform::RUBY
+  s.authors              = ["Benoit Garret"]
+  s.email                = ["benoit.garret@gadz.org"]
+  s.homepage             = "https://github.com/bgarret/google-analytics-rails"
+  s.summary              = %q{Rails 3 helpers to manage google analytics tracking}
+  s.description          = %q{Rails 3 helpers to manage google analytics tracking}
+  s.post_install_message = "Now doubleclick code is enabled by default, so please have a look on how this affect your privacy policy at:\n\thttps://support.google.com/analytics/answer/2700409"
 
   s.rubyforge_project = "google-analytics-rails"
 

--- a/lib/google-analytics-rails.rb
+++ b/lib/google-analytics-rails.rb
@@ -7,7 +7,7 @@ module GoogleAnalytics
   # @private
   PLACEHOLDER_TRACKER = "UA-xxxxxx-x"
   # @private
-  DEFAULT_SCRIPT_SOURCE = "('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js'"
+  DEFAULT_SCRIPT_SOURCE = "('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js'"
 
   # Get the current tracker id (*UA-xxxxxx-x*).
   # @return [String]
@@ -27,11 +27,12 @@ module GoogleAnalytics
   end
 
   # Get the current ga src.
-  # This allows for example to use the compatible doubleclick code :
+  # This allows for example to be used to disable the doubleclick code replacing it for the old code:
   # ```
-  #   ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js'
+  #    ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js'
   # ```
   # @see http://support.google.com/analytics/bin/answer.py?hl=en&answer=2444872 for more info
+  # @see https://support.google.com/analytics/answer/2700409
   #
   # @return [String]
   def self.script_source

--- a/test/async_tracking_queue_test.rb
+++ b/test/async_tracking_queue_test.rb
@@ -14,7 +14,7 @@ _gaq.push(['t2.event1',1]);
 _gaq.push(['t2.event2',2]);
 (function() {
 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
 var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 })();
 </script>

--- a/test/rails/views_helper_test.rb
+++ b/test/rails/views_helper_test.rb
@@ -12,7 +12,7 @@ _gaq.push(['_setDomainName','auto']);
 _gaq.push(['_trackPageview']);
 (function() {
 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
 var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 })();
 </script>
@@ -30,7 +30,7 @@ _gaq.push(['_setDomainName','auto']);
 _gaq.push(['_trackPageview','/some/virtual/url']);
 (function() {
 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
 var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 })();
 </script>
@@ -48,7 +48,7 @@ _gaq.push(['_setDomainName','auto']);
 _gaq.push(['_trackPageview']);
 (function() {
 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
 var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 })();
 </script>
@@ -66,7 +66,7 @@ _gaq.push(['_setDomainName','example.com']);
 _gaq.push(['_trackPageview']);
 (function() {
 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
 var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 })();
 </script>
@@ -85,7 +85,7 @@ _gaq.push(['_setDomainName','none']);
 _gaq.push(['_trackPageview']);
 (function() {
 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
 var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 })();
 </script>
@@ -104,7 +104,7 @@ _gaq.push(['_gat._anonymizeIp']);
 _gaq.push(['_trackPageview']);
 (function() {
 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
 var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 })();
 </script>
@@ -123,7 +123,7 @@ _gaq.push(['_setDomainName','auto']);
 _gaq.push(['_trackPageview']);
 (function() {
 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
 var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 })();
 </script>
@@ -142,7 +142,7 @@ _gaq.push(['_trackPageview']);
 _gaq.push(['_setAllowLinker',true]);
 (function() {
 var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
 var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 })();
 </script>


### PR DESCRIPTION
Hello, first of all thanks for the gem!

I'm aware that it is possible to enable dc with the version 0.0.4. But had been a while since GA update it's tracking, and I think it would be nice to have it as the default now.

I've commented on the code that the same code used before to enable it could be used now to disable it. I've also added a post install message warning those who are updating the gem.

What do you think?

Thanks!
