### PR TITLE
Add :custom_vars option

### DIFF
--- a/lib/google-analytics/rails/view_helpers.rb
+++ b/lib/google-analytics/rails/view_helpers.rb
@@ -68,6 +68,7 @@ module GoogleAnalytics::Rails
     # @option options [Boolean] :enhanced_link_attribution
     #   See separate information for multiple links on a page that all have the same destination,
     #   see {https://support.google.com/analytics/answer/2558867}.
+    # @option options [Array, GoogleAnalytics::Events::SetCustomVar] :custom_vars ([])
     #
     # @example Set the local bit in development mode
     #   analytics_init :local => Rails.env.development?
@@ -85,6 +86,8 @@ module GoogleAnalytics::Rails
 
       local = options.delete(:local) || false
       anonymize = options.delete(:anonymize) || false
+      custom_vars = options.delete(:custom_vars) || []
+      custom_vars = [custom_vars] unless custom_vars.is_a?(Array)
       link_attribution = options.delete(:enhanced_link_attribution) || false
       domain = options.delete(:domain) || (local ? "none" : "auto")
       events = options.delete(:add_events) || []
@@ -96,6 +99,10 @@ module GoogleAnalytics::Rails
       events.unshift GA::Events::TrackPageview.new(options[:page])
       # anonymize if needed before tracking the page view
       events.unshift GA::Events::AnonymizeIp.new if anonymize
+      # custom_var if needed before tracking the page view
+      custom_vars.each do |custom_var|
+        events.unshift custom_var
+      end
       events.unshift GA::Events::SetDomainName.new(domain)
       if local
         events.unshift GA::Events::SetAllowLinker.new(true)

--- a/test/rails/views_helper_test.rb
+++ b/test/rails/views_helper_test.rb
@@ -152,6 +152,25 @@ var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga
     assert_equal(VALID_EVENT_INIT, analytics_init(:add_events => GA::Events::SetAllowLinker.new(true)))
   end
 
+  VALID_EVENT_INIT_WITH_CUSTOM_VARS = <<-JAVASCRIPT
+<script type="text/javascript">
+var _gaq = _gaq || [];
+_gaq.push(['_setAccount','TEST']);
+_gaq.push(['_setDomainName','auto']);
+_gaq.push(['_setCustomVar',1,'test','hoge',1]);
+_gaq.push(['_trackPageview']);
+(function() {
+var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+})();
+</script>
+  JAVASCRIPT
+
+  def test_analytics_init_with_custom_vars
+    assert_equal(VALID_EVENT_INIT_WITH_CUSTOM_VARS, analytics_init(:custom_vars => GA::Events::SetCustomVar.new(1, 'test', 'hoge',1)))
+  end
+
   VALID_TRACK_EVENT = "_gaq.push(['_trackEvent','Videos','Play','Gone With the Wind',null]);"
 
   def test_analytics_track_event


### PR DESCRIPTION
Hello!

In the case of using `analytics_init` method, if you add additional events by `add_events` option, it is set after that `_trackPageview` request.

However, for example, as is described in the [Google Analytics Documents](https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingCustomVariables),  we need to set "_trackPageview()" request after setting a custom variable.

```
In certain cases this might not be possible, 
and you will need to set another _trackPageview() request after setting a custom variable.
```

(In my applications, _setCustomVar option has not been reflected in the Google Analytics.)

So, I changed the order in which additional events setting.
After change the order, _setCustomVar option has been reflected in the Google Analytics.

What do you think?

Thanks!
