### PR TITLE
Allow more custom dimension/metric indices

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -93,10 +93,10 @@ Premium Google Analytics accounts
 
 `config/environments/production.rb`:
 
-    # see also: https://support.google.com/analytics/answer/2709828?hl=en#Limits
-    # - premium accounts are allowed to have 200 custom dimensions/metrics
-    # - regular accounts are allowed 20;
     # add this if you have a premium account and need to use the additional dimension/metric indices
+    # - premium accounts are allowed to have 200 custom dimensions/metrics
+    # - regular accounts are allowed 20
+    # see also: https://support.google.com/analytics/answer/2709828?hl=en#Limits
     GA.premium_account = true
 
 License

--- a/README.markdown
+++ b/README.markdown
@@ -88,6 +88,17 @@ Different accounts for staging and production
 
 		<%= analytics_init if GoogleAnalytics.valid_tracker? %>
 
+Premium Google Analytics accounts
+---------------------------------
+
+`config/environments/production.rb`:
+
+    # see also: https://support.google.com/analytics/answer/2709828?hl=en#Limits
+    # - premium accounts are allowed to have 200 custom dimensions/metrics
+    # - regular accounts are allowed 20;
+    # add this if you have a premium account and need to use the additional dimension/metric indices
+    GA.premium_account = true
+
 License
 =======
 

--- a/lib/google-analytics-rails.rb
+++ b/lib/google-analytics-rails.rb
@@ -15,6 +15,10 @@ module GoogleAnalytics
     :default     => "'//www.google-analytics.com/analytics.js'",
     :doubleclick => "'//stats.g.doubleclick.net/dc.js'",
   }
+  # @private
+  MAX_REGULAR_INDICES = 20
+  # @private
+  MAX_PREMIUM_INDICES = 200
 
   # Get the current tracker id (*UA-xxxxxx-x*).
   # @return [String]
@@ -46,6 +50,23 @@ module GoogleAnalytics
     else
       @@src = src
     end
+  end
+
+  # @return [Boolean]
+  def self.premium_account?
+    @@premium_account ||= false
+  end
+
+  # Set whether or not the property is held under a premium account
+  # @param [Boolean]
+  def self.premium_account=(value)
+    @@premium_account = value
+  end
+
+  # Return the maximum number of custom dimension/metric indices for this type of account
+  # @return [Integer]
+  def self.max_custom_indices
+    premium_account? ? MAX_PREMIUM_INDICES : MAX_REGULAR_INDICES
   end
 end
 

--- a/lib/google-analytics/events/events.rb
+++ b/lib/google-analytics/events/events.rb
@@ -124,13 +124,13 @@ module GoogleAnalytics
 
     class SetCustomDimension < Event
       def initialize(index, value)
-        raise ArgumentError, "The index has to be between 1 and 5" unless (1..5).include?(index.to_i)
+        raise ArgumentError, "The index has to be between 1 and #{GA.max_custom_indices}" unless (1..GA.max_custom_indices).include?(index.to_i)
         super('set', "dimension#{index}", value.to_s)
       end
     end
     class SetCustomMetric < Event
       def initialize(index, value)
-        raise ArgumentError, "The index has to be between 1 and 5" unless (1..5).include?(index.to_i)
+        raise ArgumentError, "The index has to be between 1 and #{GA.max_custom_indices}" unless (1..GA.max_custom_indices).include?(index.to_i)
         super('set', "metric#{index}", value.to_s)
       end
     end

--- a/test/gaq_events_test.rb
+++ b/test/gaq_events_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class GAEventsTest < Test::Unit::TestCase
+  def setup
+    GA.premium_account = false
+  end
+
   def test_default_account_creation
     event = GA::Events::SetupAnalytics.new('ABC123')
     assert_equal('create', event.action)
@@ -69,6 +73,25 @@ class GAEventsTest < Test::Unit::TestCase
     assert_equal(['Search', 'Executed', 'Son of Sam', 1], event.params)
   end
 
+  def test_max_custom_indices_regular
+    assert_equal(GA::MAX_REGULAR_INDICES, GA.max_custom_indices)
+  end
+
+  def test_premium_account_defaults_to_false
+    GA.premium_account = nil
+    assert_equal(false, GA.premium_account?)
+  end
+
+  def test_max_custom_indices_defaults_to_regular
+    GA.premium_account = nil
+    assert_equal(GA::MAX_REGULAR_INDICES, GA.max_custom_indices)
+  end
+
+  def test_max_custom_indices_premium
+    GA.premium_account = true
+    assert_equal(GA::MAX_PREMIUM_INDICES, GA.max_custom_indices)
+  end
+
   def test_set_custom_dimension
     event = GA::Events::SetCustomDimension.new(1, 2)
     assert_equal('set', event.action)
@@ -76,9 +99,29 @@ class GAEventsTest < Test::Unit::TestCase
     assert_equal(['2'], event.params)
   end
 
+  def test_set_max_custom_dimension
+    assert_nothing_raised do
+      GA::Events::SetCustomDimension.new(GA::MAX_REGULAR_INDICES, 1)
+    end
+  end
+
   def test_set_custom_dimension_with_invalid_index
     assert_raise ArgumentError do
-      GA::Events::SetCustomDimension.new(6, 1)
+      GA::Events::SetCustomDimension.new(GA::MAX_REGULAR_INDICES + 1, 1)
+    end
+  end
+
+  def test_set_max_custom_dimension_premium_account
+    GA.premium_account = true
+    assert_nothing_raised do
+      GA::Events::SetCustomDimension.new(GA::MAX_PREMIUM_INDICES, 1)
+    end
+  end
+
+  def test_set_custom_dimension_with_invalid_index_premium_account
+    GA.premium_account = true
+    assert_raise ArgumentError do
+      GA::Events::SetCustomDimension.new(GA::MAX_PREMIUM_INDICES + 1, 1)
     end
   end
 
@@ -89,9 +132,29 @@ class GAEventsTest < Test::Unit::TestCase
     assert_equal(['2'], event.params)
   end
 
+  def test_set_max_custom_metric
+    assert_nothing_raised do
+      GA::Events::SetCustomMetric.new(GA::MAX_REGULAR_INDICES, 1)
+    end
+  end
+
   def test_set_custom_metric_with_invalid_index
     assert_raise ArgumentError do
-      GA::Events::SetCustomMetric.new(6, 1)
+      GA::Events::SetCustomMetric.new(GA::MAX_REGULAR_INDICES + 1, 1)
+    end
+  end
+
+  def test_set_max_custom_metric_premium_account
+    GA.premium_account = true
+    assert_nothing_raised do
+      GA::Events::SetCustomDimension.new(GA::MAX_PREMIUM_INDICES, 1)
+    end
+  end
+
+  def test_set_custom_metric_with_invalid_index_premium_account
+    GA.premium_account = true
+    assert_raise ArgumentError do
+      GA::Events::SetCustomDimension.new(GA::MAX_PREMIUM_INDICES + 1, 1)
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 require "rubygems"
 require "google-analytics-rails"
 require "test/unit"
+require "pry"
 
 GA.tracker = "TEST"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,5 @@
 require "rubygems"
 require "google-analytics-rails"
 require "test/unit"
-require "pry"
 
 GA.tracker = "TEST"


### PR DESCRIPTION
The current code limits you to only 5 custom dimension/metric indices, but Google allows for up to 20 (or 200, if you have a premium account; see also: https://support.google.com/analytics/answer/2709828?hl=en#Limits).

This change accounts for that, as well as a way to specify whether or not you have a premium account via initialization.