### PR TITLE
remove ruby 1.9.2 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ bundler_args: --without development
 before_install:
   - gem update bundler
 rvm:
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1


### PR DESCRIPTION
looks like this gem is for ruby 1.9.3 or greater according to gemspec
https://github.com/bgarret/google-analytics-rails/blob/master/google-analytics-rails.gemspec#L14