### PR TITLE
event renderer: switch to double quotes and use native json for escaping

### DIFF
--- a/lib/google-analytics/events/event_renderer.rb
+++ b/lib/google-analytics/events/event_renderer.rb
@@ -11,23 +11,18 @@ module GoogleAnalytics
 
     def to_s
       if @event.class.name == 'GoogleAnalytics::Events::SetupAnalytics'
-        "ga('#{@event.action}',#{array_to_json([@event.name, *@event.params])});"
+        %{ga("#{@event.action}",#{array_to_json([@event.name, *@event.params])});}
       elsif @event.single_event?
-        "ga('#{@tracker_id ? [@tracker_id, @event.action].join('.') : @event.action}');"
+        %{ga("#{@tracker_id ? [@tracker_id, @event.action].join('.') : @event.action}");}
       else
-        "ga('#{@tracker_id ? [@tracker_id, @event.action].join('.') : @event.action}',#{array_to_json([@event.name, *@event.params])});"
+        %{ga("#{@tracker_id ? [@tracker_id, @event.action].join('.') : @event.action}",#{array_to_json([@event.name, *@event.params])});}
       end
     end
 
     private
 
     def array_to_json(array)
-      array.map {|string| string_to_json(string) } .join(',')
-    end
-
-    def string_to_json(string)
-      # replace double quotes with single ones
-      string.to_json.gsub(/^"/, "'").gsub(/"$/, "'")
+      array.map {|val| val.to_json } .join(',')
     end
   end
 end

--- a/test/async_tracking_queue_test.rb
+++ b/test/async_tracking_queue_test.rb
@@ -11,10 +11,10 @@ class AsyncTrackingQueueTest < Test::Unit::TestCase
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-ga('send','event',1);
-ga('send','event',2);
-ga('t2.send','event',1);
-ga('t2.send','event',2);
+ga("send","event",1);
+ga("send","event",2);
+ga("t2.send","event",1);
+ga("t2.send","event",2);
 </script>
   JAVASCRIPT
 
@@ -37,10 +37,10 @@ ga('t2.send','event',2);
 #   VALID_DOUBLECLICK_SNIPPET = <<-JAVASCRIPT
 # <script type="text/javascript">
 # var _gaq = _gaq || [];
-# _gaq.push(['event1',1]);
-# _gaq.push(['event2',2]);
-# _gaq.push(['t2.event1',1]);
-# _gaq.push(['t2.event2',2]);
+# _gaq.push(["event1",1]);
+# _gaq.push(["event2",2]);
+# _gaq.push(["t2.event1",1]);
+# _gaq.push(["t2.event2",2]);
 # (function() {
 # var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
 # ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
@@ -70,10 +70,10 @@ ga('t2.send','event',2);
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','http://127.0.0.1/custom.js','ga');
-ga('send','event',1);
-ga('send','event',2);
-ga('t2.send','event',1);
-ga('t2.send','event',2);
+ga("send","event",1);
+ga("send","event",2);
+ga("t2.send","event",1);
+ga("t2.send","event",2);
 </script>
   JAVASCRIPT
 

--- a/test/event_collection_renderer_test.rb
+++ b/test/event_collection_renderer_test.rb
@@ -8,7 +8,16 @@ class EventCollectionRendererTest < Test::Unit::TestCase
     event_collection << GA::Event.new('send', 'evt', '3')
 
     ecr = GA::EventCollectionRenderer.new(event_collection, nil)
-    assert_equal("ga('send','evt','1');\nga('send','evt','2');\nga('send','evt','3');", ecr.to_s)
+    assert_equal(%{ga("send","evt","1");\nga("send","evt","2");\nga("send","evt","3");}, ecr.to_s)
+  end
+
+  def test_event_collection_renderer_escapes_quotes
+    event_collection = GA::EventCollection.new
+    event_collection << GA::Event.new('send', 'evt', "foo'sbar")
+    event_collection << GA::Event.new('send', 'evt', "foo\"sbar")
+
+    ecr = GA::EventCollectionRenderer.new(event_collection, nil)
+    assert_equal(%{ga("send","evt","foo'sbar");\nga("send","evt","foo\\"sbar");}, ecr.to_s)
   end
 
   def test_event_collection_renderer_yield_proper_javascript_snippit_for_custom_tracker
@@ -18,6 +27,6 @@ class EventCollectionRendererTest < Test::Unit::TestCase
     event_collection << GA::Event.new('send', 'evt', 3)
 
     ecr = GA::EventCollectionRenderer.new(event_collection, 't2')
-    assert_equal("ga('t2.send','evt',1);\nga('t2.send','evt',2);\nga('t2.send','evt',3);", ecr.to_s)
+    assert_equal(%{ga("t2.send","evt",1);\nga("t2.send","evt",2);\nga("t2.send","evt",3);}, ecr.to_s)
   end
 end

--- a/test/event_renderer_test.rb
+++ b/test/event_renderer_test.rb
@@ -3,12 +3,12 @@ require 'test_helper'
 class EventRendererTest < Test::Unit::TestCase
   def test_event_renderer_yield_proper_javascript_snippit_for_default_tracker
     er = GA::EventRenderer.new(GA::Event.new('send', 'something', 1, 2, 3), nil)
-    assert_equal("ga('send','something',1,2,3);", er.to_s)
+    assert_equal(%{ga("send","something",1,2,3);}, er.to_s)
   end
 
   def test_event_renderer_yield_proper_javascript_snippit_for_custom_tracker
     er = GA::EventRenderer.new(GA::Event.new('send', 'something', 1, 2, 3), 't2')
-    assert_equal("ga('t2.send','something',1,2,3);", er.to_s)
+    assert_equal(%{ga("t2.send","something",1,2,3);}, er.to_s)
   end
 
   def test_event_renderer_yield_proper_javascript_snippit_for_custom_tracker_creation
@@ -19,10 +19,10 @@ class EventRendererTest < Test::Unit::TestCase
 
   def test_single_event_renderer_yield_proper_javascript_snippit_for_transaction_send
     er = GA::EventRenderer.new(GA::Events::Ecommerce::TrackTransaction.new, nil)
-    assert_equal("ga('ecommerce:send');", er.to_s)
+    assert_equal(%{ga("ecommerce:send");}, er.to_s)
   end
   def test_single_event_renderer_yield_proper_javascript_snippit_for_transaction_send_with_custom_tracker
     er = GA::EventRenderer.new(GA::Events::Ecommerce::TrackTransaction.new, 't2')
-    assert_equal("ga('t2.ecommerce:send');", er.to_s)
+    assert_equal(%{ga("t2.ecommerce:send");}, er.to_s)
   end
 end

--- a/test/rails/views_helper_test.rb
+++ b/test/rails/views_helper_test.rb
@@ -17,8 +17,8 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-ga('create','TEST','auto');
-ga('send','pageview');
+ga("create","TEST","auto");
+ga("send","pageview");
 </script>
   JAVASCRIPT
 
@@ -29,24 +29,24 @@ ga('send','pageview');
   def test_analytics_init_with_special_name
     str = analytics_init(:name => 't2').to_s
     assert(str.include?(VALID_JS_INCLUDE))
-    assert_match(/.+ga\('create','TEST',\{.+\}\);.+/m, str)
+    assert_match(/.+ga\("create","TEST",\{.+\}\);.+/m, str)
     assert_match(/.+"cookieDomain":"auto".+/m, str)
     assert_match(/.+"name":"t2".+/m, str)
-    assert_match(/.+ga\('t2.send','pageview'\);.+/m, str)
+    assert_match(/.+ga\("t2.send","pageview"\);.+/m, str)
   end
 
   def test_analytics_init_with_virtual_pageview
     str = analytics_init(:page => '/some/virtual/url').to_s
     assert(str.include?(VALID_JS_INCLUDE))
-    assert_match(/.+ga\('create','TEST','auto'\);.+/m, str)
-    assert_match(/.+ga\('send','pageview','\/some\/virtual\/url'\);.+/m, str)
+    assert_match(/.+ga\("create","TEST","auto"\);.+/m, str)
+    assert_match(/.+ga\("send","pageview","\/some\/virtual\/url"\);.+/m, str)
   end
 
   def test_analytics_init_with_virtual_pageview_and_custom_title
     str = analytics_init(:page => '/some/virtual/url', :title => 'Hello World').to_s
     assert(str.include?(VALID_JS_INCLUDE))
-    assert_match(/.+ga\('create','TEST','auto'\);.+/m, str)
-    assert_match(/.+ga\('send','pageview'.+/m, str)
+    assert_match(/.+ga\("create","TEST","auto"\);.+/m, str)
+    assert_match(/.+ga\("send","pageview".+/m, str)
     assert_match(/.+"page":"\/some\/virtual\/url".+/m, str)
     assert_match(/.+"title":"Hello World".+/m, str)
   end
@@ -54,77 +54,77 @@ ga('send','pageview');
   def test_analytics_init_with_custom_tracker
     str = analytics_init(:tracker => 'UA-CUSTOM-XX').to_s
     assert(str.include?(VALID_JS_INCLUDE))
-    assert_match(/.+ga\('create','UA-CUSTOM-XX','auto'\);.+/m, str)
-    assert_match(/.+ga\('send','pageview'\);.+/m, str)
+    assert_match(/.+ga\("create","UA-CUSTOM-XX","auto"\);.+/m, str)
+    assert_match(/.+ga\("send","pageview"\);.+/m, str)
   end
 
   def test_analytics_init_with_custom_domain
     str = analytics_init(:domain => 'example.com').to_s
     assert(str.include?(VALID_JS_INCLUDE))
-    assert_match(/.+ga\('create','TEST',\{"cookieDomain":"example.com"\}\);.+/m, str)
-    assert_match(/.+ga\('send','pageview'\);.+/m, str)
+    assert_match(/.+ga\("create","TEST",\{"cookieDomain":"example.com"\}\);.+/m, str)
+    assert_match(/.+ga\("send","pageview"\);.+/m, str)
   end
 
   def test_local_analytics_init
     str = analytics_init(:local => true).to_s
     assert(str.include?(VALID_JS_INCLUDE))
-    assert_match(/.+ga\('create','TEST',\{.+\}\);.+/m, str)
+    assert_match(/.+ga\("create","TEST",\{.+\}\);.+/m, str)
     assert_match(/.+"cookieDomain":"none".+/m, str)
     assert_match(/.+"allowLinker":true.+/m, str)
-    assert_match(/.+ga\('send','pageview'\);.+/m, str)
+    assert_match(/.+ga\("send","pageview"\);.+/m, str)
   end
 
   def test_analytics_init_with_anonymized_ip
     str = analytics_init(:anonymize => true).to_s
     assert(str.include?(VALID_JS_INCLUDE))
-    assert_match(/.+ga\('create','TEST','auto'\);.+/m, str)
-    assert_match(/.+ga\('set','anonymizeIp',true\);.+/m, str)
-    assert_match(/.+ga\('send','pageview'\);.+/m, str)
+    assert_match(/.+ga\("create","TEST","auto"\);.+/m, str)
+    assert_match(/.+ga\("set","anonymizeIp",true\);.+/m, str)
+    assert_match(/.+ga\("send","pageview"\);.+/m, str)
   end
 
   def test_analytics_init_with_link_attribution
     str = analytics_init(:enhanced_link_attribution => true).to_s
     assert(str.include?(VALID_JS_INCLUDE))
-    assert_match(/.+ga\('create','TEST','auto'\);.+/m, str)
-    assert_match(/.+ga\('require','linkid'\);.+/m, str)
-    assert_match(/.+ga\('send','pageview'\);.+/m, str)
+    assert_match(/.+ga\("create","TEST","auto"\);.+/m, str)
+    assert_match(/.+ga\("require","linkid"\);.+/m, str)
+    assert_match(/.+ga\("send","pageview"\);.+/m, str)
   end
 
   def test_analytics_init_with_events
     str = analytics_init(:add_events => GA::Events::SetAllowLinker.new(true)).to_s
     assert(str.include?(VALID_JS_INCLUDE))
-    assert_match(/.+ga\('create','TEST',\{.+\}\);.+/m, str)
+    assert_match(/.+ga\("create","TEST",\{.+\}\);.+/m, str)
     assert_match(/.+"cookieDomain":"auto".+/m, str)
     assert_match(/.+"allowLinker":true.+/m, str)
-    assert_match(/.+ga\('send','pageview'\);.+/m, str)
+    assert_match(/.+ga\("send","pageview"\);.+/m, str)
   end
 
   def test_analytics_init_with_samplerate_events
     str = analytics_init(:add_events => GA::Events::SetSiteSpeedSampleRate.new(5)).to_s
     assert(str.include?(VALID_JS_INCLUDE))
-    assert_match(/.+ga\('create','TEST',\{.+\}\);.+/m, str)
+    assert_match(/.+ga\("create","TEST",\{.+\}\);.+/m, str)
     assert_match(/.+"cookieDomain":"auto".+/m, str)
     assert_match(/.+"siteSpeedSampleRate":5.+/m, str)
-    assert_match(/.+ga\('send','pageview'\);.+/m, str)
+    assert_match(/.+ga\("send","pageview"\);.+/m, str)
   end
 
   def test_analytics_init_with_custom_vars
     str = analytics_init(:custom_vars => GA::Events::SetCustomVar.new(1, 'test', 'hoge',1)).to_s
     assert(str.include?(VALID_JS_INCLUDE))
-    assert_match(/.+ga\('create','TEST','auto'\);.+/m, str)
-    assert_match(/.+ga\('set','dimension1','hoge'\);.+/m, str)
-    assert_match(/.+ga\('send','pageview'\);.+/m, str)
+    assert_match(/.+ga\("create","TEST","auto"\);.+/m, str)
+    assert_match(/.+ga\("set","dimension1","hoge"\);.+/m, str)
+    assert_match(/.+ga\("send","pageview"\);.+/m, str)
   end
 
   def test_analytics_init_with_custom_dimension
     str = analytics_init(:custom_vars => GA::Events::SetCustomDimension.new(1, 'hoge')).to_s
     assert(str.include?(VALID_JS_INCLUDE))
-    assert_match(/.+ga\('create','TEST','auto'\);.+/m, str)
-    assert_match(/.+ga\('set','dimension1','hoge'\);.+/m, str)
-    assert_match(/.+ga\('send','pageview'\);.+/m, str)
+    assert_match(/.+ga\("create","TEST","auto"\);.+/m, str)
+    assert_match(/.+ga\("set","dimension1","hoge"\);.+/m, str)
+    assert_match(/.+ga\("send","pageview"\);.+/m, str)
   end
 
-  VALID_TRACK_EVENT = "ga('send','event','Videos','Play','Gone With the Wind',null);"
+  VALID_TRACK_EVENT = %{ga("send","event","Videos","Play","Gone With the Wind",null);}
 
   def test_analytics_track_event
     event = analytics_track_event("Videos", "Play", "Gone With the Wind")


### PR DESCRIPTION
The JSON parser escapes with the expectation that it will be surrounded
with ". The EventRenderer was switching the leading/trailing " to a '
making the escape sequences inside invalid. That means an event with a '
will cause a Javascript error.

For example:
```ruby
    GA::Event.new('send', 'evt', "foo'sbar")
```

Would render:
```javascript
    ga('send','evt','foo'sbar')
```

Changes:
- Remove the step to convert double quotes for event parameters
- Use double quotes for the event name for consistency

I first started to fix this issue by escaping the single quotes (which would be a much smaller change) before parsing to JSON but it was a fight not work fighting. It's safer to just let the parser do it's thing. 

Fixes #36