### PR TITLE
Adding cookieFlags option

### DIFF
--- a/lib/google-analytics/events/events.rb
+++ b/lib/google-analytics/events/events.rb
@@ -21,6 +21,7 @@ module GoogleAnalytics
           :allowLinker => opts.delete(:allowLinker),
           :cookieName => opts.delete(:cookieName),
           :cookieExpires => opts.delete(:cookieExpires),
+          :cookieFlags => opts.delete(:cookieFlags),
           :sampleRate => opts.delete(:sampleRate),
           :siteSpeedSampleRate => opts.delete(:siteSpeedSampleRate),
           :name => opts.delete(:name),

--- a/test/gaq_events_test.rb
+++ b/test/gaq_events_test.rb
@@ -32,6 +32,13 @@ class GAEventsTest < Test::Unit::TestCase
     assert_equal([{:cookieDomain=>"example.com", :userId => 10}], event.params)
   end
 
+  def test_account_creation_with_cookieFlags
+    event = GA::Events::SetupAnalytics.new('ABC123', {:cookieDomain => 'example.com', :cookieFlags => 'max-age=7200;secure;samesite=none'})
+    assert_equal('create', event.action)
+    assert_equal('ABC123', event.name)
+    assert_equal([{:cookieDomain=>"example.com", :cookieFlags => 'max-age=7200;secure;samesite=none'}], event.params)
+  end
+
   def test_account_creation_with_no_cookie_domain
     event = GA::Events::SetupAnalytics.new('ABC123', 'none')
     assert_equal('create', event.action)


### PR DESCRIPTION
Add `cookieFlags` option to universal analytics init options.

```
analytics_init(cookieFlags: 'SameSite=None; Secure')
```

This will yield a

```
ga('create', 'UA-XXXX-Y', {'cookieFlags': 'SameSite=None; Secure'});
ga('send', 'pageview');
```

see also: https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#cookieFlags
